### PR TITLE
Use Ruff implementation of PyDocStyle and isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,4 @@
 repos:
-    - repo: https://github.com/pycqa/isort
-      rev: 5.13.2
-      hooks:
-          - id: isort
-            files: template
-
     - repo: https://github.com/astral-sh/ruff-pre-commit
       rev: v0.5.7
       hooks:
@@ -14,7 +8,6 @@ repos:
             files: template
           - id: ruff-format
             name: ruff formatter
-            files: template
 
     - repo: https://github.com/codespell-project/codespell
       rev: v2.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,6 @@ repos:
           - id: ruff
             name: ruff linter
             args: [--fix, --show-fixes]
-            files: template
           - id: ruff-format
             name: ruff formatter
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,13 +23,6 @@ repos:
             args: [--write-changes]
             additional_dependencies: [tomli]
 
-    - repo: https://github.com/pycqa/pydocstyle
-      rev: 6.3.0
-      hooks:
-          - id: pydocstyle
-            files: template
-            additional_dependencies: [tomli]
-
     - repo: https://github.com/mscheltienne/bibclean
       rev: 0.8.0
       hooks:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -4,6 +4,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 from __future__ import annotations
+
 import inspect
 import subprocess
 import sys
@@ -24,7 +25,7 @@ if TYPE_CHECKING:
 
 project = "template-python"
 author = "Mathieu Scheltienne"
-copyright = f"{date.today().year}, {author}"
+copyright = f"{date.today().year}, {author}"  # noqa: A001
 release = template.__version__
 package = template.__name__
 gh_url = "https://github.com/mscheltienne/template-python"
@@ -95,7 +96,7 @@ html_theme_options = {
                 <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 16 16">
                     <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path>
                 </svg>
-            """,
+            """,  # noqa: E501
             "class": "",
         },
     ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ style = [
   'yamllint',
 ]
 test = [
+  'pre-commit',
   'pytest-cov',
   'pytest-timeout',
   'pytest>=8.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,20 +67,18 @@ full = [
   'template[all]',
 ]
 stubs = [
-  'isort',
   'mypy',
-  'ruff>=0.1.8',
+  'ruff>=0.6.0',
 ]
 style = [
   'bibclean',
   'codespell[toml]>=2.2.4',
-  'isort',
-  'ruff>=0.1.8',
+  'pre-commit',
+  'ruff>=0.6.0',
   'toml-sort',
   'yamllint',
 ]
 test = [
-  'pre-commit',
   'pytest-cov',
   'pytest-timeout',
   'pytest>=8.0',
@@ -120,17 +118,6 @@ omit = [
   '**/tests/**',
 ]
 
-[tool.isort]
-extend_skip_glob = [
-  'doc/*',
-  'examples/*',
-  'tutorials/*',
-]
-line_length = 88
-multi_line_output = 3
-profile = 'black'
-py_version = 39
-
 [tool.pytest.ini_options]
 addopts = ['--color=yes', '--cov-report=', '--durations=20', '--junit-xml=junit-results.xml', '--strict-config', '--tb=short', '-ra', '-v']
 junit_family = 'xunit2'
@@ -148,14 +135,14 @@ line-ending = "lf"
 
 [tool.ruff.lint]
 ignore = []
-select = ['A', 'B', 'D', 'E', 'F', 'G', 'LOG', 'NPY', 'PIE', 'PT', 'T20', 'UP', 'W']
+select = ['A', 'B', 'D', 'E', 'F', 'G', 'I', 'LOG', 'NPY', 'PIE', 'PT', 'T20', 'UP', 'W']
 
 [tool.ruff.lint.per-file-ignores]
 '*' = [
   'B904', # 'Within an except clause, raise exceptions with raise ... from ...'
-  'D100', # undocumented public module
-  'D104', # undocumented public package
-  'D107', # undocumented public init
+  'D100', # 'Missing docstring in public module'
+  'D104', # 'Missing docstring in public package'
+  'D107', # 'Missing docstring in __init__'
   'UP007', # 'Use `X | Y` for type annotations', requires python 3.10
 ]
 '*.pyi' = ['E501']
@@ -163,7 +150,7 @@ select = ['A', 'B', 'D', 'E', 'F', 'G', 'LOG', 'NPY', 'PIE', 'PT', 'T20', 'UP', 
 
 [tool.ruff.lint.pydocstyle]
 convention = 'numpy'
-ignore-decorators = ["click.group", '(copy_doc|property|.*setter|.*getter|pyqtSlot|Slot)']
+ignore-decorators = ["template.utils._docs.copy_doc"]
 
 [tool.setuptools]
 include-package-data = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,9 +124,7 @@ junit_family = 'xunit2'
 minversion = '8.0'
 
 [tool.ruff]
-extend-exclude = [
-  'doc',
-]
+extend-exclude = []
 line-length = 88
 
 [tool.ruff.format]
@@ -147,6 +145,7 @@ select = ['A', 'B', 'D', 'E', 'F', 'G', 'I', 'LOG', 'NPY', 'PIE', 'PT', 'T20', '
 ]
 '*.pyi' = ['E501']
 '__init__.py' = ['F401']
+'tutorials/*' = ['D205', 'D400', 'T201']
 
 [tool.ruff.lint.pydocstyle]
 convention = 'numpy'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,6 @@ style = [
   'bibclean',
   'codespell[toml]>=2.2.4',
   'isort',
-  'pydocstyle[toml]',
   'ruff>=0.1.8',
   'toml-sort',
   'yamllint',
@@ -131,13 +130,6 @@ multi_line_output = 3
 profile = 'black'
 py_version = 39
 
-[tool.pydocstyle]
-add_ignore = 'D100,D104,D107'
-convention = 'numpy'
-ignore-decorators = '(copy_doc|property|.*setter|.*getter|pyqtSlot|Slot)'
-match = '^(?!__init__|test_).*\.py'
-match-dir = '^template.*'
-
 [tool.pytest.ini_options]
 addopts = ['--color=yes', '--cov-report=', '--durations=20', '--junit-xml=junit-results.xml', '--strict-config', '--tb=short', '-ra', '-v']
 junit_family = 'xunit2'
@@ -155,15 +147,22 @@ line-ending = "lf"
 
 [tool.ruff.lint]
 ignore = []
-select = ['A', 'B', 'E', 'F', 'G', 'LOG', 'NPY', 'PIE', 'PT', 'T20', 'UP', 'W']
+select = ['A', 'B', 'D', 'E', 'F', 'G', 'LOG', 'NPY', 'PIE', 'PT', 'T20', 'UP', 'W']
 
 [tool.ruff.lint.per-file-ignores]
 '*' = [
   'B904', # 'Within an except clause, raise exceptions with raise ... from ...'
+  'D100', # undocumented public module
+  'D104', # undocumented public package
+  'D107', # undocumented public init
   'UP007', # 'Use `X | Y` for type annotations', requires python 3.10
 ]
 '*.pyi' = ['E501']
 '__init__.py' = ['F401']
+
+[tool.ruff.lint.pydocstyle]
+convention = 'numpy'
+ignore-decorators = ["click.group", '(copy_doc|property|.*setter|.*getter|pyqtSlot|Slot)']
 
 [tool.setuptools]
 include-package-data = false

--- a/template/commands/main.py
+++ b/template/commands/main.py
@@ -6,8 +6,8 @@ from .sys_info import run as sys_info
 
 
 @click.group()
-def run() -> None:  # noqa: D401
-    """Main package entry-point."""
+def run() -> None:
+    """Main package entry-point."""  # noqa: D401
 
 
 run.add_command(sys_info)

--- a/tools/stubgen.py
+++ b/tools/stubgen.py
@@ -4,7 +4,6 @@ import sys
 from importlib import import_module
 from pathlib import Path
 
-import isort
 from mypy import stubgen
 
 import template
@@ -33,7 +32,6 @@ stubgen.main(
 )
 stubs = list(directory.rglob("*.pyi"))
 config = str(directory.parent / "pyproject.toml")
-config_isort = isort.settings.Config(config)
 
 # expand docstrings and inject into stub files
 for stub in stubs:
@@ -59,9 +57,12 @@ for stub in stubs:
                 method.body[0].value.value = docstring
     unparsed = ast.unparse(module_ast)
     stub.write_text(unparsed, encoding="utf-8")
-    # sort imports
-    isort.file(stub, config=config_isort)
 
 # run ruff to improve stub style
+execution = subprocess.run(
+    ["ruff", "check", str(directory), "--fix", "--unsafe-fixes", "--config", config]
+)
+if execution.returncode:
+    sys.exit(execution.returncode)
 execution = subprocess.run(["ruff", "format", str(directory), "--config", config])
 sys.exit(execution.returncode)


### PR DESCRIPTION
closes #58 

 - Removed `pydocstyle` from dependencies.
 - Removed pydocstyle from `pre-commit.yaml`
- Removed `tool.pydocstyle` from `pyproject.toml`
 - Added `tool.ruff.pydocstyle` to `pyproject.toml`
 - added `"D"` to the  `tool.ruff.lint` select option, per the  [ruff docs](https://docs.astral.sh/ruff/settings/#lintpydocstyle)
 - ported `'D100'`, `'D104'`, `'D107'` from the `tool.pydocstyle` `add_ignore` option to `tool.ruff.lint.per-file-ignores`
 - Unlike in `tool.pydocstyle`, The `tool.ruff.lint.pydocstyle` `ignore-decorators` option expects a list of `str`, not just a `str`
 - added `click.group` to `ignore-decorators` so that ruff does not raise an error for the docstring in `template.commands.main.run` (alternatively we could just make that docstring numpydoc compliant)
 - did NOT port the  `match` and `match_dir` options from `tool.pydocstyle` to `tool.ruff.lint.pydocstyle`, because these parameters dont exist in `tool.ruff.lint.pydocstyle`, and I think these configurations should already be covered by the `tool.ruff` configurations
 - Added `pre-commit` to the `test` optional-dependencies.