### PR TITLE
FIX: Import `importlib` functions directly

### DIFF
--- a/template/utils/_imports.py
+++ b/template/utils/_imports.py
@@ -6,6 +6,7 @@ Inspired from pandas: https://pandas.pydata.org/
 from __future__ import annotations
 
 import importlib
+import importlib.util
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/template/utils/_imports.py
+++ b/template/utils/_imports.py
@@ -54,7 +54,9 @@ def import_optional_dependency(
     """
     package_name = _INSTALL_MAPPING.get(name)
     install_name = package_name if package_name is not None else name
-    if importlib.util.find_spec(name) is None:
+    try:
+        return importlib.import_module(name)
+    except ImportError:
         if raise_error:
             raise ImportError(
                 f"Missing optional dependency '{install_name}'. {extra} Use pip or "
@@ -62,4 +64,3 @@ def import_optional_dependency(
             )
         else:
             return None
-    return importlib.import_module(name)

--- a/template/utils/_imports.py
+++ b/template/utils/_imports.py
@@ -5,8 +5,8 @@ Inspired from pandas: https://pandas.pydata.org/
 
 from __future__ import annotations
 
-import importlib
-import importlib.util
+from importlib import import_module
+from importlib.util import find_spec
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -55,7 +55,7 @@ def import_optional_dependency(
     """
     package_name = _INSTALL_MAPPING.get(name)
     install_name = package_name if package_name is not None else name
-    if importlib.util.find_spec(name) is None:
+    if find_spec(name) is None:
         if raise_error:
             raise ImportError(
                 f"Missing optional dependency '{install_name}'. {extra} Use pip or "
@@ -63,4 +63,4 @@ def import_optional_dependency(
             )
         else:
             return None
-    return importlib.import_module(name)
+    return import_module(name)

--- a/template/utils/_imports.py
+++ b/template/utils/_imports.py
@@ -54,9 +54,7 @@ def import_optional_dependency(
     """
     package_name = _INSTALL_MAPPING.get(name)
     install_name = package_name if package_name is not None else name
-    try:
-        return importlib.import_module(name)
-    except ImportError:
+    if importlib.util.find_spec(name) is None:
         if raise_error:
             raise ImportError(
                 f"Missing optional dependency '{install_name}'. {extra} Use pip or "
@@ -64,3 +62,4 @@ def import_optional_dependency(
             )
         else:
             return None
+    return importlib.import_module(name)


### PR DESCRIPTION
Hey @mscheltienne ,

I copied the `import_optional_dependency` code into an environment where I don't have the `template-python` deps installed, and ran into what I think is a bug in `importlib`. TL;DR in python 3.10.11+ I don't think you normally can do `importlib.util.find_spec` (see this [comment](https://discuss.python.org/t/python3-11-importlib-no-longer-exposes-util/25641/2) from a Cpython developer).

I am not 100% sure about exactly what is going on, but here is what I've found out so far:

```bash
mamba create -n "importlib_test" python=3.10.13
```

```python
# python

import importlib

importlib.util.find_spec  # raises error
```

```console
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'importlib' has no attribute 'util'
```

But I can work around this with:

```python
# python
from importlib.util import find_spec

# Now I can also do
import importlib
importlib.util.find_spec
```

So my current best guess is that one of the `template-python` dependencies does something like `from importlib.util import ...` which exposes the `importlib.util` module, allowing `template-python` to call it without issue?

___________________________________________________

Anyways, if your tests are passing on python 3.10.11+ then this might not be an actual issue. But if it is, then the PR here swaps out `importlib.util.find_spec` (which I actually really liked!) for a `try....except` block. 

Up to you on whether you want to incorporate this to `main`.